### PR TITLE
Update resource requirements and retry poclicies to make pipeline more robust

### DIFF
--- a/config/modules.config
+++ b/config/modules.config
@@ -11,22 +11,17 @@
 */
 
 process {
-    errorStrategy = { sleep(Math.pow(3, task.attempt) * 45 as long); return 'retry' }
-    maxRetries    = 5
+    errorStrategy = { sleep(Math.pow(3, task.attempt) * 60 as long); return 'retry' }
+    maxRetries    = 3
     maxErrors     = '-1'
 
     cpus = 1
     memory = 1.GB
     time = '1.0 h'
 
-    withName: SEQKIT_SAMPLE {
-        ext.args = '--rand-seed 42'
-        ext.prefix = 'subsampled'
-    }
-
     withName: 'PIPELINE:QC:FASTP' {
         cpus = 4
-        memory = 4.GB
+        memory = { 4.GB * Math.pow(2, task.attempt) }
         time = '8.0 h'
         publishDir = [
             path: { "${params.outdir}/${meta.id}/qc" },
@@ -41,6 +36,9 @@ process {
 
     withName: 'PIPELINE:READSMERGE:FASTP_PE' {
         ext.args = '--include_unmerged -A -G -Q -L'
+        cpus = 2
+        memory = { 2.GB * Math.pow(2, task.attempt) }
+        time = '8.0 h'
         publishDir = [
             path: { "${params.outdir}/${meta.id}/qc" },
             mode: params.publish_dir_mode,
@@ -54,6 +52,9 @@ process {
 
     withName: 'PIPELINE:READSMERGE:FASTP_SE' {
         ext.args = '-A -G -Q -L'
+        cpus = 2
+        memory = { 2.GB * Math.pow(2, task.attempt) }
+        time = '8.0 h'
         publishDir = [
             path: { "${params.outdir}/${meta.id}/qc" },
             mode: params.publish_dir_mode,
@@ -77,14 +78,14 @@ process {
         ext.args = '--noali --hmmonly -Z 1000 --cut_ga -o /dev/null'
         cpus = 4
         maxForks = 80
-        memory = 8.GB
+        memory = { 8.GB * Math.pow(2, task.attempt) }
         time = '8.0 h'
     }
 
     withName: MAPSEQ {
         ext.args = '--outfmt simple'
         cpus = 4
-        memory = 8.GB
+        memory = { 8.GB * Math.pow(2, task.attempt) }
         time = '4.0 h'
     }
 
@@ -122,7 +123,7 @@ process {
         ext.args = '-c -p -q'
         cpus = 4
         maxForks = 80
-        memory = 16.GB
+        memory = { 16.GB * Math.pow(2, task.attempt) }
         time = '24.0 h'
     }
 
@@ -142,6 +143,9 @@ process {
     }
 
     withName: 'PIPELINE:MOTUS_KRONA:KRONA_KTIMPORTTEXT' {
+        cpus = 1
+        memory = 1.GB
+        time = '1.0 h'
         publishDir = [
             path: { "${params.outdir}/${meta.id}/taxonomy-summary/motus" },
             mode: params.publish_dir_mode,
@@ -164,7 +168,7 @@ process {
     withName: 'PIPELINE:PROFILE_HMMSEARCH_PFAM:PARSEHMMSEARCHCOVERAGE' {
         ext.args = ""
         cpus = 1
-        memory = 16.GB
+        memory = { 16.GB * Math.pow(2, task.attempt) }
         time = '1.0 h'
         publishDir = [
             path: { "${params.outdir}/${meta.id}/function-summary/pfam" },
@@ -223,7 +227,7 @@ process {
 
     withName: SEQKIT_SHUFFLE_FASTA {
         cpus = 1
-        memory = 64.GB
+        memory = { 32.GB * Math.pow(2, task.attempt) }
         time = '8.0 h'
     }
 
@@ -232,7 +236,6 @@ process {
         memory = { 8.GB * Math.pow(2, task.attempt) }
         time = '8.0 h'
         errorStrategy = { task.exitStatus in ((130..145) + 104) ? 'retry' : 'finish' }
-        maxRetries = 3
     }
 
     withName: BBMAP_REFORMAT_STANDARDISE {
@@ -240,13 +243,12 @@ process {
         memory = { 16.GB * Math.pow(2, task.attempt) }
         time = '8.0 h'
         errorStrategy = { task.exitStatus in ((130..145) + 104) ? 'retry' : 'finish' }
-        maxRetries = 3
     }
 
     withName: CMSEARCHTBLOUTDEOVERLAP {
         cpus = 1
         memory = 1.GB
-        time = '1.0 h'
+        time = '8.0 h'
     }
 
     withName: 'PIPELINE:DECONTAM_SHORTREAD:DECONTAM_HOST' {
@@ -272,19 +274,19 @@ process {
 
     withName: EXTRACTCOORDS {
         cpus = 1
-        memory = 4.GB
-        time = '1.0 h'
+        memory = { 4.GB * Math.pow(2, task.attempt) }
+        time = '8.0 h'
     }
 
     withName: EASEL_ESLSFETCH {
         cpus = 1
-        memory = 4.GB
-        time = '1.0 h'
+        memory = { 4.GB * Math.pow(2, task.attempt) }
+        time = '8.0 h'
     }
 
     withName: MAPSEQ2BIOM {
         cpus = 1
         memory = 1.GB
-        time = '1.0 h'
+        time = '8.0 h'
     }
 }


### PR DESCRIPTION
Due constant pipeline failures due to out-of-memory I have attempted to increase the requests resources to ample but reasonable amounts.

Modified modules.config
- slightly reduced number of retries in the default retry policy (5 was a bit much)
- boosted resource requirements for a few that seemed lacking (especially fastp)
- added escalation of memory upon retry for modules where memory would scale with size of a metagenome sample
- Removed unneeded modules.config entry (seqkit_sample)