### PR TITLE
Tweak resource requirments and chunk sizes

### DIFF
--- a/config/modules.config
+++ b/config/modules.config
@@ -262,14 +262,14 @@ process {
         cpus = 1
         maxForks = 320
         memory = 1.GB
-        time = '4.0 h'
+        time = '8.0 h'
     }
 
     withName: 'PIPELINE:DECONTAM_LONGREAD:DECONTAM' {
         cpus = 4
         maxForks = 80
         memory = 16.GB
-        time = '4.0 h'
+        time = '8.0 h'
     }
 
     withName: EXTRACTCOORDS {

--- a/nextflow.config
+++ b/nextflow.config
@@ -35,9 +35,9 @@ params {
     remove_phix = true
     remove_host = true
 
-    decontam_short_chunksize = 320000000
-    decontam_long_chunksize = 6400000
-    cmsearch_chunksize = 260.MB
+    decontam_short_chunksize = 1280000000
+    decontam_long_chunksize = 12800000
+    cmsearch_chunksize = 3.GB
     hmmsearch_chunksize = 800.MB
     hmmsearch_subsampling = 2000000
 


### PR DESCRIPTION
Changed chunk sizes for a target job duration of 1 hour
- cmsearch chunks made 10x larger
- Increased decontam chunk sizes more modestly (4x for short reads, 2x for long reads)

In turn I have increased job duration requests to stay on the safe side.