### PR TITLE
Fix long-read instrument platform names to march ENA, and add support for other short-read platforms

### DIFF
--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -37,8 +37,8 @@
             },
             "instrument_platform": {
                 "type": "string",
-                "enum": ["ILLUMINA", "ONT", "PB"],
-                "errorMessage": "instrument platform should be only value from list: 'ILLUMINA', 'ONT', 'PB'"
+                "enum": ["ILLUMINA", "OXFORD_NANOPORE", "PACBIO_SMRT", "ION_TORRENT", "LS454", "DNBSEQ", "BGISEQ", "ULTIMA", "COMPLETE_GENOMICS"],
+                "errorMessage": "Instrument platform should be only value from list: 'ILLUMINA', 'OXFORD_NANOPORE', 'PACBIO_SMRT', 'ION_TORRENT', 'LS454', 'DNBSEQ', 'BGISEQ', 'ULTIMA', 'COMPLETE_GENOMICS'"
             }
         },
         "required": ["sample", "fastq_1", "single_end", "instrument_platform"]

--- a/workflows/rrap.nf
+++ b/workflows/rrap.nf
@@ -85,7 +85,7 @@ workflow PIPELINE {
     fetch_reads_transformed = samplesheet.map(groupReads)
     classified_reads = fetch_reads_transformed.map { meta, reads ->
         // Long reads
-        if (["ONT", "PB"].contains(meta.instrument_platform)) {
+        if (["OXFORD_NANOPORE", "PACBIO_SMRT"].contains(meta.instrument_platform)) {
             return [meta + [long_reads: true], reads]
         }
         else {
@@ -96,7 +96,7 @@ workflow PIPELINE {
     classified_reads
     .filter { meta, _reads -> (meta.long_reads && (!meta.single_end)) }
     .collect { meta, _reads ->
-        error "Error: Long reads (ONT or PB) cannot be paired-end — ${meta}"
+        error "Error: Long reads (OXFORD_NANOPORE or PACBIO_SMRT) cannot be paired-end — ${meta}"
     }
 
     // De-interleave interleaved paired-end reads


### PR DESCRIPTION
Pretty simple PR. I looked at the list of possible ENA instrument platforms and changed the schema to allow any short-read or long-read NGS technology since these are the only ones used for WGS raw-reads studies.
