### PR TITLE
Explicitly assume phred-33 quality encoding for BBMAP_REFORMAT

### DIFF
--- a/config/modules.config
+++ b/config/modules.config
@@ -232,17 +232,19 @@ process {
     }
 
     withName: BBMAP_REFORMAT {
+        ext.args = 'qin=33 qout=33'
         cpus = 1
         memory = { 8.GB * Math.pow(2, task.attempt) }
         time = '8.0 h'
-        errorStrategy = { task.exitStatus in ((130..145) + 104) ? 'retry' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + 104) ? 'retry' : 'terminate' }
     }
 
     withName: BBMAP_REFORMAT_STANDARDISE {
+        ext.args = 'qin=33 qout=33'
         cpus = 1
         memory = { 16.GB * Math.pow(2, task.attempt) }
         time = '8.0 h'
-        errorStrategy = { task.exitStatus in ((130..145) + 104) ? 'retry' : 'finish' }
+        errorStrategy = { task.exitStatus in ((130..145) + 104) ? 'retry' : 'terminate' }
     }
 
     withName: CMSEARCHTBLOUTDEOVERLAP {


### PR DESCRIPTION
The auto-detection was failing with oxford nanopore sequence data because the upper range was higher than BBMAP expected for a phred-33 score (it switched to phred-64 and then failed).

Assuming phred-33 is the best solution for now. If it becomes a problem then another tool could be used to detect phred-33 vs phred-64. BBMAP_REFORMAT is chosen over other tools that may perform a similar task because it handles a wide variety of input formats and standardises them well.
