### PR TITLE
Escalate memory requirements for multiqc to handle long read studies sometimes needing more memory

### DIFF
--- a/config/modules.config
+++ b/config/modules.config
@@ -212,6 +212,10 @@ process {
             pattern: "*multiqc_report.html",
             saveAs: { filename -> filename.equals('versions.yml') ? null : "study_multiqc_report.html" },
         ]
+
+        cpus = 1
+        memory = { 4.GB * Math.pow(2, task.attempt) }
+        time = '8.0 h'
     }
 
     withName: MULTIQC_RUN {
@@ -223,6 +227,10 @@ process {
             pattern: "*multiqc_report.html",
             saveAs: { filename -> filename.equals('versions.yml') ? null : "${meta.id}_multiqc_report.html" },
         ]
+
+        cpus = 1
+        memory = { 4.GB * Math.pow(2, task.attempt) }
+        time = '8.0 h'
     }
 
     withName: SEQKIT_SHUFFLE_FASTA {


### PR DESCRIPTION
Very little PR. The multiQC job sometimes runs out of memory for long-read studies, so I've added a memory escalation on retry.