### PR TITLE
Increase cmsearch (and hmmsearch) resource requirments, and an escalate policy for cpus.

### DIFF
--- a/config/modules.config
+++ b/config/modules.config
@@ -76,10 +76,11 @@ process {
 
     withName: 'PIPELINE:RRNA_EXTRACTION:INFERNAL_CMSEARCH' {
         ext.args = '--noali --hmmonly -Z 1000 --cut_ga -o /dev/null'
-        cpus = 4
-        maxForks = 80
-        memory = { 8.GB * Math.pow(2, task.attempt) }
-        time = '8.0 h'
+        cpus = { 2 * Math.pow(2, task.attempt) }
+        maxForks = 160
+        memory = { 4.GB + 4.GB * Math.pow(2, task.attempt) }
+        time = '12.0 h'
+        maxRetries = 3
     }
 
     withName: MAPSEQ {
@@ -159,10 +160,11 @@ process {
 
     withName: 'PIPELINE:PROFILE_HMMSEARCH_PFAM:HMMER_HMMSEARCH' {
         ext.args = "-Z ${params.databases.pfam.variables.num_models} --cut_ga --noali"
-        cpus = 2
-        maxForks = 250
-        memory = 1.GB
-        time = '8.0 h'
+        cpus = { 2 * Math.pow(2, task.attempt) }
+        maxForks = 160
+        memory = { 1.GB + 1.GB * Math.pow(2, task.attempt) }
+        time = '12.0 h'
+        maxRetries = 3
     }
 
     withName: 'PIPELINE:PROFILE_HMMSEARCH_PFAM:PARSEHMMSEARCHCOVERAGE' {

--- a/nextflow.config
+++ b/nextflow.config
@@ -38,7 +38,7 @@ params {
     decontam_short_chunksize = 1280000000
     decontam_long_chunksize = 12800000
     cmsearch_chunksize = 3.GB
-    hmmsearch_chunksize = 800.MB
+    hmmsearch_chunksize = 1.GB
     hmmsearch_subsampling = 2000000
 
     force_download_dbs = false


### PR DESCRIPTION
Performing raw-reads pipeline pressure test in production. This is a modification of resource requirement parameters.

cmsearch was timing out with long-read samples. Need to escalate CPUs to speed them up. Also increased time limit to 12 hours,