### PR TITLE
Remove incorrect resourceLimits statements

### DIFF
--- a/conf/local.config
+++ b/conf/local.config
@@ -9,9 +9,6 @@ params {
 process {
     executor = 'local'
 
-    cpus = 1
-    memory = 1.GB
-
     withName: SEQKIT_SHUFFLE_FASTA {
         cpus = 1
         memory = 16.GB

--- a/conf/local.config
+++ b/conf/local.config
@@ -8,8 +8,9 @@ params {
 
 process {
     executor = 'local'
-    
-    resourceLimits  = [ cpus: 1, memory: 1.GB ]
+
+    cpus = 1
+    memory = 1.GB
 
     withName: SEQKIT_SHUFFLE_FASTA {
         cpus = 1

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -15,10 +15,6 @@ process {
     maxRetries    = 3
     maxErrors     = '-1'
 
-    cpus = 1
-    memory = 1.GB
-    time = 1.h
-
     withName: 'PIPELINE:QC:FASTP' {
         cpus = 4
         memory = { 4.GB * Math.pow(2, task.attempt) }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -15,7 +15,9 @@ process {
     maxRetries    = 3
     maxErrors     = '-1'
 
-    resourceLimits = [ cpus: 1, memory: 1.GB, time: 1.h ]
+    cpus = 1
+    memory = 1.GB
+    time = 1.h
 
     withName: 'PIPELINE:QC:FASTP' {
         cpus = 4


### PR DESCRIPTION
resourceLimits statements were not being used correctly. They were reducing requested memory for jobs even when other resource requirements were stated for specific modules (i.e. the resourceLimits were not being over-riden in a more-narrow scope). 