### PR TITLE
Loosen validation of paired-end reads, fix tests

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -15,6 +15,12 @@ process {
     maxRetries    = 3
     maxErrors     = '-1'
 
+    withName: 'PIPELINE:DOWNLOAD_FROM_FIRE' {
+        cpus = 1
+        memory = { 6.GB * task.attempt }
+        time   = { 4.h * task.attempt }
+    }
+
     withName: 'PIPELINE:QC:FASTP' {
         cpus = 4
         memory = { 4.GB * Math.pow(2, task.attempt) }

--- a/conf/test.config
+++ b/conf/test.config
@@ -107,15 +107,14 @@ params {
     }
 }
 
+executor {
+    name = 'slurm'
+    queueSize = 30
+    queueGlobalStatus = true
+}
 process {
-    executor {
-        name = 'slurm'
-        queueSize = 30
-        queueGlobalStatus = true
-    }
     queue = 'standard'
     cache = 'lenient'
-
     resourceLimits = [
         cpu: 2,
         memory: 8.GB

--- a/conf/test.config
+++ b/conf/test.config
@@ -12,6 +12,8 @@ params {
     hmmsearch_chunksize = 800.MB
     hmmsearch_subsampling = 2000000
 
+    publish_dir_mode = 'copy'
+
     databases {
         cache_path = "download_cache/databases"
 
@@ -164,6 +166,15 @@ process {
     withName: 'PIPELINE:QC:FASTP' {
         cpus = 2
         memory = 1.GB
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}/qc" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename ->
+                if (filename.contains('.json')) {
+                    return "${meta.id}_qc.fastp.json"
+                }
+            },
+        ]
     }
 
     withName: MAPSEQ {
@@ -174,5 +185,14 @@ process {
     withName: 'PIPELINE:PROFILE_HMMSEARCH_PFAM:PARSEHMMSEARCHCOVERAGE' {
         cpus = 1
         memory = 1.GB
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}/function-summary/pfam" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename ->
+                if (filename.contains('.json')) {
+                    return "${meta.id}_pfam.stats.json"
+                }
+            },
+        ]
     }
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -108,6 +108,26 @@ params {
 }
 
 process {
+    withName: 'PIPELINE:QC:FASTP' {
+        cpus = 2
+        memory = 1.GB
+    }
+
+    withName: 'PIPELINE:DECONTAM_SHORTREAD:DECONTAM_HOST' {
+        cpus = 2
+        memory = 1.GB
+    }
+
+    withName: 'PIPELINE:DECONTAM_LONGREAD:DECONTAM' {
+        cpus = 2
+        memory = 1.GB
+    }
+
+    withName: MAPSEQ {
+        cpus = 2
+        memory = 1.GB
+    }
+
     withName: 'PIPELINE:RRNA_EXTRACTION:INFERNAL_CMSEARCH' {
         cpus = 2
         memory = 1.GB

--- a/conf/test.config
+++ b/conf/test.config
@@ -108,6 +108,8 @@ params {
 }
 
 process {
+    executor = 'local'
+
     withName: SEQKIT_SHUFFLE_FASTA {
         cpus = 1
         memory = 1.GB

--- a/conf/test.config
+++ b/conf/test.config
@@ -126,6 +126,7 @@ process {
     }
 
     withName: 'PIPELINE:MOTUS_KRONA:MOTUS_PROFILE' {
+        ext.args = '-c -p -q'
         cpus = 2
         memory = 1.GB
     }

--- a/conf/test.config
+++ b/conf/test.config
@@ -107,7 +107,16 @@ params {
     }
 }
 
+executor {
+    name = 'slurm'
+    queueSize = 30
+    queueGlobalStatus = true
+}
+
 process {
+    queue = 'standard'
+    cache = 'lenient'
+
     resourceLimits = [
         cpu: 2,
         memory: 8.GB

--- a/conf/test.config
+++ b/conf/test.config
@@ -135,7 +135,7 @@ process {
         memory = 1.GB
     }
 
-    withName: HMMER_HMMSEARCH {
+    withName: 'PIPELINE:PROFILE_HMMSEARCH_PFAM:HMMER_HMMSEARCH' {
         cpus = 2
         memory = 1.GB
     }

--- a/conf/test.config
+++ b/conf/test.config
@@ -125,7 +125,7 @@ process {
         memory = 1.GB
     }
 
-    withName: MOTUS_PROFILE {
+    withName: 'PIPELINE:MOTUS_KRONA:MOTUS_PROFILE' {
         cpus = 2
         memory = 1.GB
     }

--- a/conf/test.config
+++ b/conf/test.config
@@ -165,6 +165,11 @@ process {
         memory = 1.GB
     }
 
+    withName: 'PIPELINE:QC:FASTP' {
+        cpus = 2
+        memory = 1.GB
+    }
+
     withName: MAPSEQ {
         cpus = 2
         memory = 1.GB

--- a/conf/test.config
+++ b/conf/test.config
@@ -107,8 +107,19 @@ params {
     }
 }
 
+executor {
+    name = 'slurm'
+    queueSize = 30
+    queueGlobalStatus = true
+}
 process {
-    executor = 'local'
+    queue = 'standard'
+    cache = 'lenient'
+
+    resourceLimits = [
+        cpu: 2,
+        memory: 8.GB
+    ]
 
     withName: SEQKIT_SHUFFLE_FASTA {
         cpus = 1
@@ -126,19 +137,16 @@ process {
     }
 
     withName: 'PIPELINE:MOTUS_KRONA:MOTUS_PROFILE' {
-        ext.args = '-c -p -q'
         cpus = 2
         memory = 1.GB
     }
 
     withName: 'PIPELINE:RRNA_EXTRACTION:INFERNAL_CMSEARCH' {
-        ext.args = '--noali --hmmonly -Z 1000 --cut_ga -o /dev/null'
         cpus = 2
         memory = 1.GB
     }
 
     withName: 'PIPELINE:PROFILE_HMMSEARCH_PFAM:HMMER_HMMSEARCH' {
-        ext.args = "-Z ${params.databases.pfam.variables.num_models} --cut_ga --noali"
         cpus = 2
         memory = 1.GB
     }
@@ -166,15 +174,6 @@ process {
     withName: 'PIPELINE:QC:FASTP' {
         cpus = 2
         memory = 1.GB
-        publishDir = [
-            path: { "${params.outdir}/${meta.id}/qc" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename ->
-                if (filename.contains('.json')) {
-                    return "${meta.id}_qc.fastp.json"
-                }
-            },
-        ]
     }
 
     withName: MAPSEQ {
@@ -185,14 +184,5 @@ process {
     withName: 'PIPELINE:PROFILE_HMMSEARCH_PFAM:PARSEHMMSEARCHCOVERAGE' {
         cpus = 1
         memory = 1.GB
-        publishDir = [
-            path: { "${params.outdir}/${meta.id}/function-summary/pfam" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename ->
-                if (filename.contains('.json')) {
-                    return "${meta.id}_pfam.stats.json"
-                }
-            },
-        ]
     }
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -110,8 +110,6 @@ params {
 }
 
 process {
-    executor = 'local'
-
     withName: SEQKIT_SHUFFLE_FASTA {
         cpus = 1
         memory = 1.GB

--- a/conf/test.config
+++ b/conf/test.config
@@ -12,6 +12,8 @@ params {
     hmmsearch_chunksize = 800.MB
     hmmsearch_subsampling = 2000000
 
+    publish_dir_mode = 'copy'
+
     databases {
         cache_path = "download_cache/databases"
 
@@ -124,6 +126,7 @@ process {
     }
 
     withName: 'PIPELINE:MOTUS_KRONA:MOTUS_PROFILE' {
+        ext.args = '-c -p -q'
         cpus = 2
         memory = 1.GB
     }
@@ -161,6 +164,15 @@ process {
     withName: 'PIPELINE:QC:FASTP' {
         cpus = 2
         memory = 1.GB
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}/qc" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename ->
+                if (filename.contains('.json')) {
+                    return "${meta.id}_qc.fastp.json"
+                }
+            },
+        ]
     }
 
     withName: MAPSEQ {
@@ -171,5 +183,14 @@ process {
     withName: 'PIPELINE:PROFILE_HMMSEARCH_PFAM:PARSEHMMSEARCHCOVERAGE' {
         cpus = 1
         memory = 1.GB
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}/function-summary/pfam" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename ->
+                if (filename.contains('.json')) {
+                    return "${meta.id}_pfam.stats.json"
+                }
+            },
+        ]
     }
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -113,6 +113,11 @@ process {
         memory = 1.GB
     }
 
+    withName: FASTP {
+        cpus = 2
+        memory = 1.GB
+    }
+
     withName: 'PIPELINE:DECONTAM_SHORTREAD:DECONTAM_HOST' {
         cpus = 2
         memory = 1.GB

--- a/conf/test.config
+++ b/conf/test.config
@@ -130,7 +130,7 @@ process {
         memory = 1.GB
     }
 
-    withName: INFERNAL_CMSEARCH {
+    withName: 'PIPELINE:RRNA_EXTRACTION:INFERNAL_CMSEARCH' {
         cpus = 2
         memory = 1.GB
     }
@@ -157,11 +157,6 @@ process {
 
     withName: EASEL_ESLSFETCH {
         cpus = 1
-        memory = 1.GB
-    }
-
-    withName: FASTP {
-        cpus = 2
         memory = 1.GB
     }
 

--- a/conf/test.config
+++ b/conf/test.config
@@ -108,5 +108,70 @@ params {
 }
 
 process {
-    resourceLimits = [cpu: 2, memory: 4.GB]
+    executor = 'local'
+
+    withName: SEQKIT_SHUFFLE_FASTA {
+        cpus = 1
+        memory = 1.GB
+    }
+
+    withName: BBMAP_REFORMAT {
+        cpus = 1
+        memory = 1.GB
+    }
+
+    withName: BBMAP_REFORMAT_STANDARDISE {
+        cpus = 1
+        memory = 1.GB
+    }
+
+    withName: MOTUS_PROFILE {
+        cpus = 2
+        memory = 1.GB
+    }
+
+    withName: INFERNAL_CMSEARCH {
+        cpus = 2
+        memory = 1.GB
+    }
+
+    withName: HMMER_HMMSEARCH {
+        cpus = 2
+        memory = 1.GB
+    }
+
+    withName: 'PIPELINE:DECONTAM_SHORTREAD:DECONTAM_HOST' {
+        cpus = 2
+        memory = 1.GB
+    }
+
+    withName: 'PIPELINE:DECONTAM_LONGREAD:DECONTAM' {
+        cpus = 2
+        memory = 1.GB
+    }
+
+    withName: EXTRACTCOORDS {
+        cpus = 1
+        memory = 1.GB
+    }
+
+    withName: EASEL_ESLSFETCH {
+        cpus = 1
+        memory = 1.GB
+    }
+
+    withName: FASTP {
+        cpus = 2
+        memory = 1.GB
+    }
+
+    withName: MAPSEQ {
+        cpus = 2
+        memory = 1.GB
+    }
+
+    withName: 'PIPELINE:PROFILE_HMMSEARCH_PFAM:PARSEHMMSEARCHCOVERAGE' {
+        cpus = 1
+        memory = 1.GB
+    }
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -12,8 +12,6 @@ params {
     hmmsearch_chunksize = 800.MB
     hmmsearch_subsampling = 2000000
 
-    publish_dir_mode = 'copy'
-
     databases {
         cache_path = "download_cache/databases"
 
@@ -110,6 +108,11 @@ params {
 }
 
 process {
+    resourceLimits = [
+        cpu: 2,
+        memory: 8.GB
+    ]
+
     withName: SEQKIT_SHUFFLE_FASTA {
         cpus = 1
         memory = 1.GB
@@ -132,11 +135,13 @@ process {
     }
 
     withName: 'PIPELINE:RRNA_EXTRACTION:INFERNAL_CMSEARCH' {
+        ext.args = '--noali --hmmonly -Z 1000 --cut_ga -o /dev/null'
         cpus = 2
         memory = 1.GB
     }
 
     withName: 'PIPELINE:PROFILE_HMMSEARCH_PFAM:HMMER_HMMSEARCH' {
+        ext.args = "-Z ${params.databases.pfam.variables.num_models} --cut_ga --noali"
         cpus = 2
         memory = 1.GB
     }

--- a/conf/test.config
+++ b/conf/test.config
@@ -107,15 +107,7 @@ params {
     }
 }
 
-executor {
-    name = 'slurm'
-    queueSize = 30
-    queueGlobalStatus = true
-}
 process {
-    queue = 'standard'
-    cache = 'lenient'
-
     resourceLimits = [
         cpu: 2,
         memory: 8.GB

--- a/conf/test.config
+++ b/conf/test.config
@@ -108,43 +108,5 @@ params {
 }
 
 process {
-    withName: 'PIPELINE:QC:FASTP' {
-        cpus = 2
-        memory = 1.GB
-    }
-
-    withName: FASTP {
-        cpus = 2
-        memory = 1.GB
-    }
-
-    withName: 'PIPELINE:DECONTAM_SHORTREAD:DECONTAM_HOST' {
-        cpus = 2
-        memory = 1.GB
-    }
-
-    withName: 'PIPELINE:DECONTAM_LONGREAD:DECONTAM' {
-        cpus = 2
-        memory = 1.GB
-    }
-
-    withName: MAPSEQ {
-        cpus = 2
-        memory = 1.GB
-    }
-
-    withName: 'PIPELINE:RRNA_EXTRACTION:INFERNAL_CMSEARCH' {
-        cpus = 2
-        memory = 1.GB
-    }
-
-    withName: 'PIPELINE:MOTUS_KRONA:MOTUS_PROFILE' {
-        cpus = 2
-        memory = 4.GB
-    }
-
-    withName: 'PIPELINE:PROFILE_HMMSEARCH_PFAM:HMMER_HMMSEARCH' {
-        cpus = 2
-        memory = 1.GB
-    }
+    resourceLimits = [cpu: 2, memory: 4.GB]
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -12,8 +12,6 @@ params {
     hmmsearch_chunksize = 800.MB
     hmmsearch_subsampling = 2000000
 
-    publish_dir_mode = 'copy'
-
     databases {
         cache_path = "download_cache/databases"
 
@@ -126,7 +124,6 @@ process {
     }
 
     withName: 'PIPELINE:MOTUS_KRONA:MOTUS_PROFILE' {
-        ext.args = '-c -p -q'
         cpus = 2
         memory = 1.GB
     }
@@ -164,15 +161,6 @@ process {
     withName: 'PIPELINE:QC:FASTP' {
         cpus = 2
         memory = 1.GB
-        publishDir = [
-            path: { "${params.outdir}/${meta.id}/qc" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename ->
-                if (filename.contains('.json')) {
-                    return "${meta.id}_qc.fastp.json"
-                }
-            },
-        ]
     }
 
     withName: MAPSEQ {
@@ -183,14 +171,5 @@ process {
     withName: 'PIPELINE:PROFILE_HMMSEARCH_PFAM:PARSEHMMSEARCHCOVERAGE' {
         cpus = 1
         memory = 1.GB
-        publishDir = [
-            path: { "${params.outdir}/${meta.id}/function-summary/pfam" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename ->
-                if (filename.contains('.json')) {
-                    return "${meta.id}_pfam.stats.json"
-                }
-            },
-        ]
     }
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -107,19 +107,7 @@ params {
     }
 }
 
-executor {
-    name = 'slurm'
-    queueSize = 30
-    queueGlobalStatus = true
-}
 process {
-    queue = 'standard'
-    cache = 'lenient'
-    resourceLimits = [
-        cpu: 2,
-        memory: 8.GB
-    ]
-
     withName: SEQKIT_SHUFFLE_FASTA {
         cpus = 1
         memory = 1.GB

--- a/conf/test.config
+++ b/conf/test.config
@@ -107,13 +107,12 @@ params {
     }
 }
 
-executor {
-    name = 'slurm'
-    queueSize = 30
-    queueGlobalStatus = true
-}
-
 process {
+    executor {
+        name = 'slurm'
+        queueSize = 30
+        queueGlobalStatus = true
+    }
     queue = 'standard'
     cache = 'lenient'
 

--- a/modules/local/bbmap/reformat_standardise/main.nf
+++ b/modules/local/bbmap/reformat_standardise/main.nf
@@ -27,7 +27,7 @@ process BBMAP_REFORMAT_STANDARDISE {
     in_reads  = single_file ? "in=${reads[0]}" : "in=${reads[0]} in2=${reads[1]}"
     out_reads = meta.single_end ? "out=${prefix}_reformated.${out_fmt}" : "out=${prefix}_1_reformated.${out_fmt} out2=${prefix}_2_reformated.${out_fmt} outs=${prefix}_singleton.${out_fmt}"
     interleaved_cmd = meta.interleaved ? "int=t verifyinterleaved=t" : ""
-    paired_cmd = meta.single_end ? "" : "addslash=t spaceslash=f verifypaired=t"
+    paired_cmd = meta.single_end ? "" : "addslash=t spaceslash=f verifypaired=f"
 
     """
     maxmem=\$(echo \"$task.memory\"| sed 's/ GB/g/g')

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,8 +18,6 @@ nextflow {
 cleanup = true
 nextflow.enable.moduleBinaries = true
 
-includeConfig 'conf/base.config'
-includeConfig 'conf/modules.config'
 
 params {
     singularity_cachedir = "singularity_cache"
@@ -192,6 +190,9 @@ params {
     }
 }
 
+
+includeConfig 'conf/base.config'
+includeConfig 'conf/modules.config'
 
 apptainer.registry = 'quay.io'
 docker.registry = 'quay.io'

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,6 +18,9 @@ nextflow {
 cleanup = true
 nextflow.enable.moduleBinaries = true
 
+includeConfig 'conf/base.config'
+includeConfig 'conf/modules.config'
+
 params {
     singularity_cachedir = "singularity_cache"
 
@@ -271,5 +274,3 @@ profiles {
     }
 }
 
-includeConfig 'conf/base.config'
-includeConfig 'conf/modules.config'

--- a/nextflow.config
+++ b/nextflow.config
@@ -219,6 +219,8 @@ dag {
     overwrite = true
 }
 
+includeConfig 'conf/base.config'
+
 profiles {
     singularity {
         singularity {
@@ -271,4 +273,3 @@ profiles {
 }
 
 includeConfig 'conf/modules.config'
-includeConfig 'conf/base.config'

--- a/nextflow.config
+++ b/nextflow.config
@@ -219,7 +219,6 @@ dag {
     overwrite = true
 }
 
-includeConfig 'conf/base.config'
 includeConfig 'conf/modules.config'
 
 profiles {
@@ -273,3 +272,4 @@ profiles {
     }
 }
 
+includeConfig 'conf/base.config'

--- a/nextflow.config
+++ b/nextflow.config
@@ -219,6 +219,9 @@ dag {
     overwrite = true
 }
 
+includeConfig 'conf/base.config'
+includeConfig 'conf/modules.config'
+
 profiles {
     singularity {
         singularity {
@@ -270,5 +273,3 @@ profiles {
     }
 }
 
-includeConfig 'conf/base.config'
-includeConfig 'conf/modules.config'

--- a/nextflow.config
+++ b/nextflow.config
@@ -219,8 +219,6 @@ dag {
     overwrite = true
 }
 
-includeConfig 'conf/modules.config'
-
 profiles {
     singularity {
         singularity {
@@ -272,4 +270,5 @@ profiles {
     }
 }
 
+includeConfig 'conf/modules.config'
 includeConfig 'conf/base.config'

--- a/nextflow.config
+++ b/nextflow.config
@@ -31,6 +31,7 @@ params {
     publish_dir_mode = 'copy'
 
     // --- RUNNING PARAMETERS
+    skip_standardise = true
     skip_qc = false
     skip_decontam = false
     skip_functional = true

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,7 +18,6 @@ nextflow {
 cleanup = true
 nextflow.enable.moduleBinaries = true
 
-
 params {
     singularity_cachedir = "singularity_cache"
 
@@ -190,10 +189,6 @@ params {
     }
 }
 
-
-includeConfig 'conf/base.config'
-includeConfig 'conf/modules.config'
-
 apptainer.registry = 'quay.io'
 docker.registry = 'quay.io'
 podman.registry = 'quay.io'
@@ -275,3 +270,5 @@ profiles {
     }
 }
 
+includeConfig 'conf/base.config'
+includeConfig 'conf/modules.config'

--- a/nf-test.config
+++ b/nf-test.config
@@ -2,7 +2,7 @@ config {
     testsDir "tests"
     workDir System.getenv("NFT_WORKDIR") ?: ".nf-test"
     configFile "tests/nextflow.config"
-    profile "test"
+    profile "test,local"
     ignore 'modules/nf-core/**/tests/*', 'subworkflows/nf-core/**/tests/*'
     triggers 'nextflow.config', 'nf-test.config', 'conf/test.config', 'tests/nextflow.config', 'tests/.nftignore'
     plugins {

--- a/nf-test.config
+++ b/nf-test.config
@@ -2,7 +2,7 @@ config {
     testsDir "tests"
     workDir System.getenv("NFT_WORKDIR") ?: ".nf-test"
     configFile "tests/nextflow.config"
-    profile "test,local"
+    profile "test"
     ignore 'modules/nf-core/**/tests/*', 'subworkflows/nf-core/**/tests/*'
     triggers 'nextflow.config', 'nf-test.config', 'conf/test.config', 'tests/nextflow.config', 'tests/.nftignore'
     plugins {

--- a/nf-test.config
+++ b/nf-test.config
@@ -2,7 +2,7 @@ config {
     testsDir "tests"
     workDir System.getenv("NFT_WORKDIR") ?: ".nf-test"
     configFile "tests/nextflow.config"
-    profile "test"
+    profile "local,test"
     ignore 'modules/nf-core/**/tests/*', 'subworkflows/nf-core/**/tests/*'
     triggers 'nextflow.config', 'nf-test.config', 'conf/test.config', 'tests/nextflow.config', 'tests/.nftignore'
     plugins {

--- a/nf-test.config
+++ b/nf-test.config
@@ -2,7 +2,7 @@ config {
     testsDir "tests"
     workDir System.getenv("NFT_WORKDIR") ?: ".nf-test"
     configFile "tests/nextflow.config"
-    profile "test,local"
+    profile "local,test"
     ignore 'modules/nf-core/**/tests/*', 'subworkflows/nf-core/**/tests/*'
     triggers 'nextflow.config', 'nf-test.config', 'conf/test.config', 'tests/nextflow.config', 'tests/.nftignore'
     plugins {

--- a/nf-test.config
+++ b/nf-test.config
@@ -2,7 +2,7 @@ config {
     testsDir "tests"
     workDir System.getenv("NFT_WORKDIR") ?: ".nf-test"
     configFile "tests/nextflow.config"
-    profile "local,test"
+    profile "test"
     ignore 'modules/nf-core/**/tests/*', 'subworkflows/nf-core/**/tests/*'
     triggers 'nextflow.config', 'nf-test.config', 'conf/test.config', 'tests/nextflow.config', 'tests/.nftignore'
     plugins {

--- a/nf-test.config
+++ b/nf-test.config
@@ -2,7 +2,7 @@ config {
     testsDir "tests"
     workDir System.getenv("NFT_WORKDIR") ?: ".nf-test"
     configFile "tests/nextflow.config"
-    profile "local,test"
+    profile "test,local"
     ignore 'modules/nf-core/**/tests/*', 'subworkflows/nf-core/**/tests/*'
     triggers 'nextflow.config', 'nf-test.config', 'conf/test.config', 'tests/nextflow.config', 'tests/.nftignore'
     plugins {

--- a/tests/main.nf.test.snap
+++ b/tests/main.nf.test.snap
@@ -23,19 +23,19 @@
                 "taxonomy-summary/silva-ssu/test_sample_silva-ssu.txt.gz"
             ],
             [
-                "test_sample_pfam.stats.json:md5,1398b0e8e44a56d74891aa17c878abbd",
-                "test_sample_pfam.txt.gz:md5,f2c1b6442e65db826e68e016c865b0e5",
+                "test_sample_pfam.stats.json:md5,097f23d280452214f42549f5a8ca69f2",
+                "test_sample_pfam.txt.gz:md5,0255099c4e549c0a337dacc368c279fc",
                 "test_sample_decontamination.fastp.json:md5,76ce3f45c65d86e88e29348080a2b146",
-                "test_sample_qc.fastp.json:md5,31897b2c0c7247b194531d46924a9935",
+                "test_sample_qc.fastp.json:md5,16a50fee34550679c7755b457961f57a",
                 "test_sample_motus.txt.gz:md5,200e14493ea87181d9f3a01728ab812a",
-                "test_sample_silva-lsu.txt.gz:md5,f360b7687eca3c7ee302d895545b3a74",
-                "test_sample_silva-ssu.txt.gz:md5,70354dfb7e270fe17d79894822e75b87"
+                "test_sample_silva-lsu.txt.gz:md5,2186a26a1be44ca50d855c21c138a1ab",
+                "test_sample_silva-ssu.txt.gz:md5,4db0cc9f568584cf7300a217639da805"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.10.2"
         },
-        "timestamp": "2025-12-15T14:54:05.046815366"
+        "timestamp": "2025-12-16T12:50:08.176481099"
     }
 }

--- a/tests/main.nf.test.snap
+++ b/tests/main.nf.test.snap
@@ -23,19 +23,19 @@
                 "taxonomy-summary/silva-ssu/test_sample_silva-ssu.txt.gz"
             ],
             [
-                "test_sample_pfam.stats.json:md5,097f23d280452214f42549f5a8ca69f2",
-                "test_sample_pfam.txt.gz:md5,0255099c4e549c0a337dacc368c279fc",
-                "test_sample_decontamination.fastp.json:md5,e6f15cfb36ea5b8900b6a9c4274df4e9",
-                "test_sample_qc.fastp.json:md5,baa329f4fe8c5b91a9f4857c5bbff5d2",
+                "test_sample_pfam.stats.json:md5,1398b0e8e44a56d74891aa17c878abbd",
+                "test_sample_pfam.txt.gz:md5,f2c1b6442e65db826e68e016c865b0e5",
+                "test_sample_decontamination.fastp.json:md5,76ce3f45c65d86e88e29348080a2b146",
+                "test_sample_qc.fastp.json:md5,31897b2c0c7247b194531d46924a9935",
                 "test_sample_motus.txt.gz:md5,200e14493ea87181d9f3a01728ab812a",
-                "test_sample_silva-lsu.txt.gz:md5,2186a26a1be44ca50d855c21c138a1ab",
-                "test_sample_silva-ssu.txt.gz:md5,4db0cc9f568584cf7300a217639da805"
+                "test_sample_silva-lsu.txt.gz:md5,f360b7687eca3c7ee302d895545b3a74",
+                "test_sample_silva-ssu.txt.gz:md5,70354dfb7e270fe17d79894822e75b87"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-11-10T10:11:34.41131909"
+        "timestamp": "2025-12-15T14:54:05.046815366"
     }
 }

--- a/workflows/rrap.nf
+++ b/workflows/rrap.nf
@@ -118,6 +118,7 @@ workflow PIPELINE {
     if (!params.skip_standardise) {
         // De-interleave interleaved paired-end reads
         BBMAP_REFORMAT_STANDARDISE(classified_reads, 'fastq.gz')
+        ch_versions = ch_versions.mix(BBMAP_REFORMAT_STANDARDISE.out.versions)
         classified_reads = BBMAP_REFORMAT_STANDARDISE.out.reformated
     }
 

--- a/workflows/rrap.nf
+++ b/workflows/rrap.nf
@@ -115,9 +115,11 @@ workflow PIPELINE {
         error "Error: Long reads (OXFORD_NANOPORE or PACBIO_SMRT) cannot be paired-end — ${meta}"
     }
 
-    // De-interleave interleaved paired-end reads
-    BBMAP_REFORMAT_STANDARDISE(classified_reads, 'fastq.gz')
-    classified_reads = BBMAP_REFORMAT_STANDARDISE.out.reformated
+    if (!params.skip_standardise) {
+        // De-interleave interleaved paired-end reads
+        BBMAP_REFORMAT_STANDARDISE(classified_reads, 'fastq.gz')
+        classified_reads = BBMAP_REFORMAT_STANDARDISE.out.reformated
+    }
 
     // QC
     if (params.skip_qc) {


### PR DESCRIPTION
- Loosen validation of paired-end reads by bbmap, allowing mismatches to proceed.
- Add flag to bypass initial bbmap reads validation and standardisation. Bypassing is true by default. This initial check/standardisation should not be run with reads from ENA, the purpose is rather for data from less-trusted sources.
- Discovered whole-pipeline test was failing. Needed to 1) remove local profile from nf-test config, 2) add some resource requirements to test.config, and 3) add slurm executor to test.config. Snapshots were updated due to changed initial bbmap step.