### PR TITLE
Fix header repetition in hmm output

### DIFF
--- a/modules/local/combinehmmsearchtbl/main.nf
+++ b/modules/local/combinehmmsearchtbl/main.nf
@@ -14,7 +14,7 @@ process COMBINEHMMSEARCHTBL {
 
     """
     export inputs=\$(find -L inputs -name "*tbl.gz")
-    export first_file=\$(echo \$inputs | head -n 1)
+    export first_file=\$(echo \$inputs | cut -d' ' -f1)
     gunzip -c \${first_file} | grep '#' > header.txt || true
     cat \$inputs | gunzip | grep -v '#' > without_header.txt || true
     cat header.txt without_header.txt | gzip > ${output_name} || true


### PR DESCRIPTION
When the chunked hmm outputs are concatenated we get multiple copies of the header in the output file.
$inputs is a space separated list so $first_file is currently all of the files
