### PR TITLE
Bugfix parsing HMMer outputs for functional profiling

### DIFF
--- a/modules/local/parsehmmsearchcoverage/bin/hmmer_domtbl_parse_coverage.py
+++ b/modules/local/parsehmmsearchcoverage/bin/hmmer_domtbl_parse_coverage.py
@@ -111,7 +111,7 @@ if __name__ == '__main__':
             hmm_hit_count[d['query_accession']].add(k)
             if not d['query_accession'] in hmm_hits_coverage:
                 hmm_hits_coverage[d['query_accession']] = {i+1:0 for i in range(d['qlen'])}
-            for i in range(d['hmm_coord_from'], d['hmm_coord_to']):
+            for i in range(d['hmm_coord_from'], d['hmm_coord_to']+1):
                 hmm_hits_coverage[d['query_accession']][i] += 1
     hmm_hit_count = {k:len(vs) for k,vs in hmm_hit_count.items()}
 
@@ -119,8 +119,6 @@ if __name__ == '__main__':
     hmm_hits_coverage_stats = {}
     for k,d in hmm_hits_coverage.items():
         if not len(d)>0:
-            continue
-        if not sum(list(d.values()))>0:
             continue
         depth = sum(list(d.values()))/len(d)
         breadth = sum([v>0 for _,v in d.items()])/len(d)

--- a/modules/local/parsehmmsearchcoverage/bin/hmmer_domtbl_parse_coverage.py
+++ b/modules/local/parsehmmsearchcoverage/bin/hmmer_domtbl_parse_coverage.py
@@ -120,6 +120,8 @@ if __name__ == '__main__':
     for k,d in hmm_hits_coverage.items():
         if not len(d)>0:
             continue
+        if not sum(list(d.values()))>0:
+            continue
         depth = sum(list(d.values()))/len(d)
         breadth = sum([v>0 for _,v in d.items()])/len(d)
 

--- a/modules/local/parsehmmsearchcoverage/bin/hmmer_domtbl_parse_coverage.py
+++ b/modules/local/parsehmmsearchcoverage/bin/hmmer_domtbl_parse_coverage.py
@@ -94,7 +94,7 @@ if __name__ == '__main__':
             start, end = d['read_frame'][1:3]
 
             m = lambda x: (start-1)+direction*(x-1)*3 + (phase-1)
-            nt_base_idxs = list(range(*list(sorted((m(d['ali_coord_from']), m(d['ali_coord_to']))))))
+            nt_base_idxs = list(range(*list(sorted((m(d['ali_coord_from']), m(d['ali_coord_to']+1))))))
 
             if not any([i in ali_coverage for i in nt_base_idxs]):
                 deoverlapped.append(d)

--- a/tests/main.nf.test.snap
+++ b/tests/main.nf.test.snap
@@ -14,16 +14,16 @@
             ],
             [
                 "test_sample_pfam.stats.json:md5,097f23d280452214f42549f5a8ca69f2",
-                "test_sample_pfam.txt.gz:md5,0255099c4e549c0a337dacc368c279fc",
+                "test_sample_pfam.txt.gz:md5,0b58cbccbf672ec4e6adf3b993f8403d",
                 "test_sample_decontamination.fastp.json:md5,8bad8b44fd86db42db3b3d4ff4ca849b",
                 "test_sample_qc.fastp.json:md5,151817020501968c3db33ac038fc5eb7"
             ]
         ],
+        "timestamp": "2026-03-02T10:05:10.917917",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-02-25T10:58:12.10883"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     },
     "Should run without failures": {
         "content": [
@@ -50,7 +50,7 @@
             ],
             [
                 "test_sample_pfam.stats.json:md5,097f23d280452214f42549f5a8ca69f2",
-                "test_sample_pfam.txt.gz:md5,0255099c4e549c0a337dacc368c279fc",
+                "test_sample_pfam.txt.gz:md5,0b58cbccbf672ec4e6adf3b993f8403d",
                 "test_sample_decontamination.fastp.json:md5,8bad8b44fd86db42db3b3d4ff4ca849b",
                 "test_sample_qc.fastp.json:md5,151817020501968c3db33ac038fc5eb7",
                 "test_sample_motus.txt.gz:md5,200e14493ea87181d9f3a01728ab812a",
@@ -58,10 +58,10 @@
                 "test_sample_silva-ssu.txt.gz:md5,4db0cc9f568584cf7300a217639da805"
             ]
         ],
+        "timestamp": "2026-03-02T10:04:29.150549",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.0"
-        },
-        "timestamp": "2026-01-15T12:04:58.013509"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     }
 }


### PR DESCRIPTION
The coordinate system in the HMMer outputs is not the same as the indexing system in Python. WIth a 'from' and 'to' set of coordinates in the HMMer output, the 'to' coordinate needed to be incremented by 1 when used to slice and select items in Python lists.

Manifested as a downstream 'division by 0' error. It has been verified that this fix resolves that error.