### PR TITLE
Make meaningful krona.html when taxonomies are empty

### DIFF
--- a/modules/ebi-metagenomics/krona/ktimporttext/main.nf
+++ b/modules/ebi-metagenomics/krona/ktimporttext/main.nf
@@ -1,6 +1,6 @@
 // This krona/ktimporttext module is copied from the already-existing nf-core module (https://nf-co.re/modules/krona_ktimporttext, https://github.com/nf-core/modules/commit/8fc1d24c710ebe1d5de0f2447ec9439fd3d9d66a)
 // This is because there are not currently any nf-core ways of adding modules from more than one nf-core repo
-// One slight change compared to the original is I've added a stub to this module
+// Two slight changes compared to the original is I've added a stub to this module, and it outputs a meaningful message to HTML if the data are empty
 
 process KRONA_KTIMPORTTEXT {
     tag "$meta.id"
@@ -22,14 +22,23 @@ process KRONA_KTIMPORTTEXT {
     task.ext.when == null || task.ext.when
 
     script:
-    def args = task.ext.args ?: ''
+    def args   = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    ktImportText  \\
-        $args \\
-        -o ${prefix}.html \\
-        $report
-
+    if grep -qvE '^[[:space:]]*(#|$)' "$report"; then
+        ktImportText \\
+            $args \\
+            -o "${prefix}.html" \\
+            "$report"
+    else
+        cat > "${prefix}.html" <<EOF
+<html>
+<body>
+<h2>No taxonomic classifications were produced for this sample.</h2>
+</body>
+</html>
+EOF
+    fi
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         krona: \$( echo \$(ktImportText 2>&1) | sed 's/^.*KronaTools //g; s/- ktImportText.*\$//g')


### PR DESCRIPTION
Currently the krona.html looks "broken" when the mapseq file contains no taxa.
I assume it is "correct" pipeline logic to still output this, e.g. [Motus on MGYA01027244
](https://www.ebi.ac.uk/metagenomics/analyses/MGYA01027244/taxonomic). This PR just makes a meaningful message HTML instead of the empty-looking Krona.